### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-sky-03d109d1e.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-sky-03d109d1e.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
@@ -40,6 +44,8 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    permissions:
+      contents: read
     steps:
       - name: Close Pull Request
         id: closepullrequest


### PR DESCRIPTION
Potential fix for [https://github.com/DevMan01/devhood.net/security/code-scanning/2](https://github.com/DevMan01/devhood.net/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the jobs to function correctly. For the `build_and_deploy_job`, we will grant `contents: read` and `pull-requests: write` permissions, as it interacts with the repository contents and may need to comment on pull requests. For the `close_pull_request_job`, we will grant only `contents: read` permissions, as it does not require write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
